### PR TITLE
feat: add ability to subscribe to certain namespaces for

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ type Message struct {
 }
 ```
 
+## Subscribe to namespaces
+```go
+ch, err = queue.Subscribe("default")
+if err != nil { }
+
+for {
+    select {
+        case mEvent, ok := <-ch:
+            if !ok {
+                return
+            }
+
+            m, err := queue.Lock(mEvent.MessageID)
+            // do something with m
+    }
+}
+```
+
 ## Marking a Job as Done or Failed
 ```go
 err = queue.Done(messageID)

--- a/queue.go
+++ b/queue.go
@@ -62,7 +62,14 @@ type Queue interface {
 	Retry(id int64) error
 	// Size returns the size of the queue
 	Size() (int, error)
+    // Lock provides direct access to lock the message.
+    // This is used mostly by the subscription mechanism.
     Lock(messageID int64) (*Message, error)
+    // Subscribe returns a channel that will receive messages as they are enqueued
+    // this provides a simple way to implement pub/sub.
+    // Note that the jobs are not consumed from the queue, they are just sent to the
+    // channel as they are enqueued and if work needs to happen on them you'd have to lock
+    // them using the Lock(id) method.
 	Subscribe(namespace string) (MessagesCh, error)
 	// Prune deletes completed jobs
 	Prune() error

--- a/queue_test.go
+++ b/queue_test.go
@@ -95,6 +95,33 @@ func TestGoqueueLiteSize(t *testing.T) {
 	q.Close()
 }
 
+
+func TestGoqueueLiteSubscribe(t *testing.T) {
+	t.Parallel()
+	q, err := goqueuelite.New(goqueuelite.Params{
+		DatabasePath: ":memory:",
+	})
+	assert.NoError(t, err)
+
+    ch, err := q.Subscribe("default")
+	assert.NoError(t, err)
+    assert.NotNil(t, ch)
+
+	_, err = q.Enqueue("default", goqueuelite.EnqueueParams{})
+	assert.NoError(t, err)
+
+    m := <-ch
+    assert.NotNil(t, m)
+    assert.NotZero(t, m.MessageID)
+    assert.Equal(t, m.Namespace, "default")
+
+    mm, err := q.Lock(m.MessageID)
+    assert.NoError(t, err)
+    assert.Equal(t, m.MessageID, mm.ID)
+
+	q.Close()
+}
+
 func TestGoqueueLiteDequeue(t *testing.T) {
 	t.Parallel()
 	q, err := goqueuelite.New(goqueuelite.Params{


### PR DESCRIPTION
message notifications

In order to not automtically lock the resources I've introduced a Lock method in the interface to let the client decide if they just want the notification or also lock the message for use.

I'd recommend not to use Subscribe + Dequeue at the same time. Pick one or the other.